### PR TITLE
MOD-1696 storage macros; RwLock to RefCell

### DIFF
--- a/examples/gpt2/package-lock.json
+++ b/examples/gpt2/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "hello-world",
+  "name": "gpt2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hello-world",
+      "name": "gpt2",
       "workspaces": [
         "src/frontend"
       ]

--- a/examples/gpt2/src/model/src/storage/base.rs
+++ b/examples/gpt2/src/model/src/storage/base.rs
@@ -1,59 +1,57 @@
 // src/storage/base.rs
 use std::cell::RefCell;
-use bytes::Bytes;
-use crate::auth::is_authenticated;
 use crate::MAP;
-use std::sync::RwLock;
-use paste::paste;
+
+// We know this is safe because IC canisters are single-threaded
+pub struct ICRefCell<T>(RefCell<T>);
+unsafe impl<T> Sync for ICRefCell<T> {}
+
+impl<T> ICRefCell<T> {
+    pub const fn new(value: T) -> Self {
+        Self(RefCell::new(value))
+    }
+}
 
 // Core storage trait
 pub trait Storage {
     fn append_bytes(&self, bytes: Vec<u8>);
     fn bytes_length(&self) -> usize;
     fn clear_bytes(&self);
-    fn call_bytes(&self) -> Result<Bytes, String>;
+    fn call_bytes(&self) -> Result<Vec<u8>, String>;
 }
-
 
 pub struct GenericStorage {
     name: &'static str,
-    ref_cell: &'static RwLock<Vec<u8>>,
+    cell: &'static ICRefCell<Vec<u8>>,
 }
 
 impl GenericStorage {
-    pub const fn new(name: &'static str, ref_cell: &'static RwLock<Vec<u8>>) -> Self {
-        Self { name, ref_cell }
+    pub const fn new(name: &'static str, cell: &'static ICRefCell<Vec<u8>>) -> Self {
+        Self { name, cell }
     }
 }
 
 impl Storage for GenericStorage {
     fn append_bytes(&self, bytes: Vec<u8>) {
-        self.ref_cell.write().unwrap().extend(bytes);
+        self.cell.0.borrow_mut().extend(bytes);
     }
 
     fn bytes_length(&self) -> usize {
-        self.ref_cell.read().unwrap().len()
+        self.cell.0.borrow().len()
     }
 
     fn clear_bytes(&self) {
-        self.ref_cell.write().unwrap().clear();
+        self.cell.0.borrow_mut().clear();
     }
 
-    fn call_bytes(&self) -> Result<Bytes, String> {
+    fn call_bytes(&self) -> Result<Vec<u8>, String> {
         let mut data = Vec::new();
-        std::mem::swap(&mut data, &mut *self.ref_cell.write().unwrap());
-        Ok(Bytes::from(data))
+        std::mem::swap(&mut data, &mut *self.cell.0.borrow_mut());
+        Ok(data)
     }
 }
 
-// Helper struct for IC methods
-pub struct StorageIcMethods {
-    pub append_bytes: Box<dyn Fn(Vec<u8>)>,
-    pub bytes_length: Box<dyn Fn() -> usize>,
-    pub clear_bytes: Box<dyn Fn()>,
-}
-
-// Stable storage trait
+// Optional stable storage trait
 pub trait StableStorage {
     fn store_to_stable(&self, key: u8) -> Result<(), String>;
     fn load_from_stable(&self, key: u8) -> Result<(), String>;
@@ -66,7 +64,7 @@ impl StableStorage for GenericStorage {
 
         MAP.with(|p| {
             let mut map = p.borrow_mut();
-            map.insert(key, bytes.to_vec());
+            map.insert(key, bytes);
         });
 
         Ok(())
@@ -85,44 +83,55 @@ impl StableStorage for GenericStorage {
     }
 }
 
-// Macros
+// New macro for declaring storage
 #[macro_export]
-macro_rules! create_storage {
-    ($vis:vis $name:ident, $storage_name:expr) => {
-        thread_local! {
-            static REF_CELL: RefCell<Vec<u8>> = RefCell::new(vec![]);
+macro_rules! declare_storage {
+    (
+        $(#[$meta:meta])*
+        $vis:vis $name:ident {
+            name: $storage_name:expr,
+            $(stable_key: $stable_key:expr)?
         }
+    ) => {
+        paste::paste! {
+            static [<$name _CELL>]: crate::storage::base::ICRefCell<Vec<u8>> =
+                crate::storage::base::ICRefCell::new(Vec::new());
 
-        $vis static $name: GenericStorage = GenericStorage::new($storage_name, &REF_CELL);
+            $(#[$meta])*
+            $vis static $name: GenericStorage =
+                GenericStorage::new($storage_name, &[<$name _CELL>]);
 
-        #[ic_cdk::update(guard = "is_authenticated")]
-        $vis fn paste_ident!(append_, $name:lower, _bytes)(bytes: Vec<u8>) {
-            $name.append_bytes(bytes);
-        }
+            #[ic_cdk::update(guard = "is_authenticated")]
+            $vis fn [<append_ $name:lower _bytes>](bytes: Vec<u8>) {
+                $name.append_bytes(bytes);
+            }
 
-        #[ic_cdk::query]
-        $vis fn paste_ident!($name:lower, _bytes_length)() -> usize {
-            $name.bytes_length()
-        }
+            #[ic_cdk::query]
+            $vis fn [<$name:lower _bytes_length>]() -> usize {
+                $name.bytes_length()
+            }
 
-        #[ic_cdk::update(guard = "is_authenticated")]
-        $vis fn paste_ident!(clear_, $name:lower, _bytes)() {
-            $name.clear_bytes();
-        }
-    };
-}
+            #[ic_cdk::update(guard = "is_authenticated")]
+            $vis fn [<clear_ $name:lower _bytes>]() {
+                $name.clear_bytes();
+            }
 
-#[macro_export]
-macro_rules! create_stable_storage_methods {
-    ($storage:expr, $key:expr) => {
-        #[ic_cdk::update(guard = "is_authenticated")]
-        pub fn paste_ident!(store_, $storage:lower, _bytes_to_stable)() -> Result<(), String> {
-            $storage.store_to_stable($key)
-        }
+            #[ic_cdk::update(guard = "is_authenticated")]
+            $vis fn [<call_ $name:lower _bytes>]() -> Result<Vec<u8>, String> {
+                $name.call_bytes()
+            }
 
-        #[ic_cdk::update(guard = "is_authenticated")]
-        pub fn paste_ident!(load_, $storage:lower, _bytes_from_stable)() -> Result<(), String> {
-            $storage.load_from_stable($key)
+            $(
+                #[ic_cdk::update(guard = "is_authenticated")]
+                $vis fn [<store_ $name:lower _bytes_to_stable>]() -> Result<(), String> {
+                    $name.store_to_stable($stable_key)
+                }
+
+                #[ic_cdk::update(guard = "is_authenticated")]
+                $vis fn [<load_ $name:lower _bytes_from_stable>]() -> Result<(), String> {
+                    $name.load_from_stable($stable_key)
+                }
+            )?
         }
     };
 }

--- a/examples/gpt2/src/model/src/storage/instances.rs
+++ b/examples/gpt2/src/model/src/storage/instances.rs
@@ -1,80 +1,31 @@
 // storage/instances.rs
-use std::sync::RwLock;
+use super::declare_storage;
 use crate::auth::is_authenticated;
 use crate::storage::GenericStorage;
-use crate::storage::base::{Storage, StableStorage};
+use std::cell::RefCell;
+use crate::storage::base::StableStorage;
+use crate::storage::base::Storage;
 
-static CONFIG_CELL: RwLock<Vec<u8>> = RwLock::new(vec![]);
-static SAFETENSORS_CELL: RwLock<Vec<u8>> = RwLock::new(vec![]);
-static TOKENIZER_CELL: RwLock<Vec<u8>> = RwLock::new(vec![]);
-
-pub static CONFIG: GenericStorage = GenericStorage::new("config", &CONFIG_CELL);
-pub static SAFETENSORS: GenericStorage = GenericStorage::new("safetensors", &SAFETENSORS_CELL);
-pub static TOKENIZER: GenericStorage = GenericStorage::new("tokenizer", &TOKENIZER_CELL);
-
-// IC interface functions
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn append_config_bytes(bytes: Vec<u8>) {
-    CONFIG.append_bytes(bytes);
+declare_storage! {
+    /// Configuration storage
+    pub CONFIG {
+        name: "config",
+        stable_key: 2
+    }
 }
 
-#[ic_cdk::query]
-pub fn config_bytes_length() -> usize {
-    CONFIG.bytes_length()
+declare_storage! {
+    /// SafeTensors model weights storage
+    pub SAFETENSORS {
+        name: "safetensors",
+        stable_key: 0
+    }
 }
 
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn clear_config_bytes() {
-    CONFIG.clear_bytes();
-}
-
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn append_safetensors_bytes(bytes: Vec<u8>) {
-    SAFETENSORS.append_bytes(bytes);
-}
-
-#[ic_cdk::query]
-pub fn safetensors_bytes_length() -> usize {
-    SAFETENSORS.bytes_length()
-}
-
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn clear_safetensors_bytes() {
-    SAFETENSORS.clear_bytes();
-}
-
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn append_tokenizer_bytes(bytes: Vec<u8>) {
-    TOKENIZER.append_bytes(bytes);
-}
-
-#[ic_cdk::query]
-pub fn tokenizer_bytes_length() -> usize {
-    TOKENIZER.bytes_length()
-}
-
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn clear_tokenizer_bytes() {
-    TOKENIZER.clear_bytes();
-}
-
-
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn store_tokenizer_bytes_to_stable() -> Result<(), String> {
-    TOKENIZER.store_to_stable(1)
-}
-
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn load_tokenizer_bytes_from_stable() -> Result<(), String> {
-    TOKENIZER.load_from_stable(1)
-}
-
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn store_safetensors_bytes_to_stable() -> Result<(), String> {
-    SAFETENSORS.store_to_stable(0)
-}
-
-#[ic_cdk::update(guard = "is_authenticated")]
-pub fn load_safetensors_bytes_from_stable() -> Result<(), String> {
-    SAFETENSORS.load_from_stable(0)
+declare_storage! {
+    /// Tokenizer data storage
+    pub TOKENIZER {
+        name: "tokenizer",
+        stable_key: 1
+    }
 }

--- a/examples/gpt2/src/model/src/storage/mod.rs
+++ b/examples/gpt2/src/model/src/storage/mod.rs
@@ -3,24 +3,19 @@ mod base;
 mod instances;
 
 pub use base::{Storage, GenericStorage, StableStorage};
+
+// Re-export the macro for use in other modules
+pub use crate::declare_storage;
+
+// Re-export the storage instances and their functions
 pub use instances::{
     CONFIG, SAFETENSORS, TOKENIZER,
-    append_config_bytes, config_bytes_length, clear_config_bytes,
-    append_safetensors_bytes, safetensors_bytes_length, clear_safetensors_bytes,
-    append_tokenizer_bytes, tokenizer_bytes_length, clear_tokenizer_bytes,
-    store_tokenizer_bytes_to_stable, load_tokenizer_bytes_from_stable,
+    append_config_bytes, config_bytes_length, clear_config_bytes, call_config_bytes,
+    store_config_bytes_to_stable, load_config_bytes_from_stable,
+
+    append_safetensors_bytes, safetensors_bytes_length, clear_safetensors_bytes, call_safetensors_bytes,
     store_safetensors_bytes_to_stable, load_safetensors_bytes_from_stable,
+
+    append_tokenizer_bytes, tokenizer_bytes_length, clear_tokenizer_bytes, call_tokenizer_bytes,
+    store_tokenizer_bytes_to_stable, load_tokenizer_bytes_from_stable,
 };
-
-pub fn call_config_bytes() -> Result<bytes::Bytes, String> {
-    CONFIG.call_bytes()
-}
-
-pub fn call_safetensors_bytes() -> Result<bytes::Bytes, String> {
-    SAFETENSORS.call_bytes()
-}
-
-pub fn call_tokenizer_bytes() -> Result<bytes::Bytes, String> {
-    TOKENIZER.call_bytes()
-}
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved storage management mechanism
	- Introduced a new thread-safe storage cell type
	- Simplified storage declaration and handling
	- Updated storage macro for more flexible key management

- **Changes**
	- Replaced `RwLock` with a custom `ICRefCell` for safer storage operations
	- Modified storage initialization and byte handling methods
	- Removed explicit byte calling functions
	- Consolidated storage export structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->